### PR TITLE
remove unnecessary dependency on argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=1.6
-argparse
 six>=1.9.0


### PR DESCRIPTION
argparse is not required for Python 2.7 and 3.4 (which are the only
Python versions explicitely supported in setup.py)

removing the unnecessary argparse dependency to allow package to be
properly packaged on Debian/Ubuntu systems.