### PR TITLE
Fix: Undeclared setuptools dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
+setuptools


### PR DESCRIPTION
We recently upgraded some of our CI/CD build pipelines in Jenkins to JJB==6.0.0. 

Since then, our builds broke:

https://github.com/lfit/releng-global-jjb/actions/runs/8066815554/job/22035827260

`jjb: commands[0]> jenkins-jobs -l DEBUG test --recursive -o /home/runner/work/releng-global-jjb/releng-global-jjb/archives/job-configs /home/runner/work/releng-global-jjb/releng-global-jjb/jjb:/home/runner/work/releng-global-jjb/releng-global-jjb/.jjb-test
ERROR:stevedore.extension:Could not load 'delete': No module named 'pkg_resources'
ERROR:stevedore.extension:Could not load 'delete-all': No module named 'pkg_resources'
ERROR:stevedore.extension:Could not load 'get-plugins-info': No module named 'pkg_resources'
ERROR:stevedore.extension:Could not load 'list': No module named 'pkg_resources'
ERROR:stevedore.extension:Could not load 'test': No module named 'pkg_resources'
ERROR:stevedore.extension:Could not load 'update': No module named 'pkg_resources'
Traceback (most recent call last):
  File "/home/runner/work/releng-global-jjb/releng-global-jjb/.tox/jjb/bin/jenkins-jobs", line 8, in <module>
    sys.exit(main())`

This was due to setuptools being required by stevedore but was an undeclared dependency. This single line patch adds the missing dependency.